### PR TITLE
[FLINK-36931-contrib] Simplify UdfE2eITCase using @ParameterizedTest

### DIFF
--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/UdfE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/UdfE2eITCase.java
@@ -96,6 +96,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
     @ParameterizedTest(name = "language: {0}, batchMode: {1}")
     @MethodSource(value = "variants")
     void testUserDefinedFunctions(String language, boolean batchMode) throws Exception {
+        String startupMode = batchMode ? "snapshot" : "initial";
         String pipelineJob =
                 String.format(
                         "source:\n"
@@ -104,6 +105,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                                 + "  port: 3306\n"
                                 + "  username: %s\n"
                                 + "  password: %s\n"
+                                + "  scan.startup.mode: %s\n"
                                 + "  tables: %s.\\.*\n"
                                 + "  server-id: 5400-5404\n"
                                 + "  server-time-zone: UTC\n"
@@ -134,6 +136,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                         INTER_CONTAINER_MYSQL_ALIAS,
                         MYSQL_TEST_USER,
                         MYSQL_TEST_PASSWORD,
+                        startupMode,
                         transformRenameDatabase.getDatabaseName(),
                         transformRenameDatabase.getDatabaseName(),
                         transformRenameDatabase.getDatabaseName(),
@@ -198,7 +201,12 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                                 "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2014, 14, Forty-two, Integer: 2014], op=INSERT, meta=()}",
                                 transformRenameDatabase.getDatabaseName()));
         validateResult(expectedEvents);
+
+        if (batchMode) {
+            return;
+        }
         LOG.info("Begin incremental reading stage.");
+
         // generate binlogs
         String mysqlJdbcUrl =
                 String.format(
@@ -240,6 +248,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
     @ParameterizedTest(name = "language: {0}, batchMode: {1}")
     @MethodSource(value = "variants")
     void testFlinkCompatibleScalarFunctions(String language, boolean batchMode) throws Exception {
+        String startupMode = batchMode ? "snapshot" : "initial";
         String pipelineJob =
                 String.format(
                         "source:\n"
@@ -248,6 +257,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                                 + "  port: 3306\n"
                                 + "  username: %s\n"
                                 + "  password: %s\n"
+                                + "  scan.startup.mode: %s\n"
                                 + "  tables: %s.\\.*\n"
                                 + "  server-id: 5400-5404\n"
                                 + "  server-time-zone: UTC\n"
@@ -274,6 +284,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                         INTER_CONTAINER_MYSQL_ALIAS,
                         MYSQL_TEST_USER,
                         MYSQL_TEST_PASSWORD,
+                        startupMode,
                         transformRenameDatabase.getDatabaseName(),
                         transformRenameDatabase.getDatabaseName(),
                         transformRenameDatabase.getDatabaseName(),
@@ -334,6 +345,10 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                                 "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2014, 14, Integer: 2014], op=INSERT, meta=()}",
                                 transformRenameDatabase.getDatabaseName()));
         validateResult(expectedEvents);
+
+        if (batchMode) {
+            return;
+        }
         LOG.info("Begin incremental reading stage.");
         // generate binlogs
         String mysqlJdbcUrl =

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/UdfE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/UdfE2eITCase.java
@@ -25,7 +25,9 @@ import org.apache.flink.cdc.pipeline.tests.utils.PipelineTestEnvironment;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -40,6 +42,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 
 /** E2e tests for User-defined functions. */
 class UdfE2eITCase extends PipelineTestEnvironment {
@@ -82,47 +85,17 @@ class UdfE2eITCase extends PipelineTestEnvironment {
         transformRenameDatabase.dropDatabase();
     }
 
-    @Test
-    void testUserDefinedFunctionsInJava() throws Exception {
-        testUserDefinedFunctions("java");
+    private static Stream<Arguments> variants() {
+        return Stream.of(
+                Arguments.of("java", true),
+                Arguments.of("java", false),
+                Arguments.of("scala", true),
+                Arguments.of("scala", false));
     }
 
-    @Test
-    void testUserDefinedFunctionsInJavaInBatchMode() throws Exception {
-        testUserDefinedFunctionsInBatchMode("java");
-    }
-
-    @Test
-    void testUserDefinedFunctionsInScala() throws Exception {
-        testUserDefinedFunctions("scala");
-    }
-
-    @Test
-    void testUserDefinedFunctionsInScalaInBatchMode() throws Exception {
-        testUserDefinedFunctionsInBatchMode("scala");
-    }
-
-    @Test
-    void testFlinkCompatibleScalarFunctionsInJava() throws Exception {
-        testFlinkCompatibleScalarFunctions("java");
-    }
-
-    @Test
-    void testFlinkCompatibleScalarFunctionsInJavaInBatchMode() throws Exception {
-        testFlinkCompatibleScalarFunctionsInBatchMode("java");
-    }
-
-    @Test
-    void testFlinkCompatibleScalarFunctionsInScala() throws Exception {
-        testFlinkCompatibleScalarFunctions("scala");
-    }
-
-    @Test
-    void testFlinkCompatibleScalarFunctionsInScalaInBatchMode() throws Exception {
-        testFlinkCompatibleScalarFunctionsInBatchMode("scala");
-    }
-
-    private void testUserDefinedFunctions(String language) throws Exception {
+    @ParameterizedTest(name = "language: {0}, batchMode: {1}")
+    @MethodSource(value = "variants")
+    void testUserDefinedFunctions(String language, boolean batchMode) throws Exception {
         String pipelineJob =
                 String.format(
                         "source:\n"
@@ -146,6 +119,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                                 + "\n"
                                 + "pipeline:\n"
                                 + "  parallelism: %d\n"
+                                + "  batch-mode.enabled: %s\n"
                                 + "  user-defined-function:\n"
                                 + "    - name: addone\n"
                                 + "      classpath: org.apache.flink.cdc.udf.examples.%s.AddOneFunctionClass\n"
@@ -164,6 +138,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                         transformRenameDatabase.getDatabaseName(),
                         transformRenameDatabase.getDatabaseName(),
                         parallelism,
+                        batchMode,
                         language,
                         language,
                         language,
@@ -262,112 +237,9 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                 20000L);
     }
 
-    private void testUserDefinedFunctionsInBatchMode(String language) throws Exception {
-        String pipelineJob =
-                String.format(
-                        "source:\n"
-                                + "  type: mysql\n"
-                                + "  hostname: %s\n"
-                                + "  port: 3306\n"
-                                + "  username: %s\n"
-                                + "  password: %s\n"
-                                + "  tables: %s.\\.*\n"
-                                + "  server-id: 5400-5404\n"
-                                + "  server-time-zone: UTC\n"
-                                + "  scan.startup.mode: snapshot\n"
-                                + "\n"
-                                + "sink:\n"
-                                + "  type: values\n"
-                                + "transform:\n"
-                                + "  - source-table: %s.TABLEALPHA\n"
-                                + "    projection: ID, VERSION, addone(addone(ID)) AS INC_ID, format('<%%s>', VERSION) AS FMT_VER\n"
-                                + "    filter: addone(ID) <> '1009'\n"
-                                + "  - source-table: %s.TABLEBETA\n"
-                                + "    projection: ID, VERSION, answer() AS ANS, typeof(ID) AS TYP\n"
-                                + "\n"
-                                + "pipeline:\n"
-                                + "  parallelism: %d\n"
-                                + "  batch-mode.enabled: true\n"
-                                + "  user-defined-function:\n"
-                                + "    - name: addone\n"
-                                + "      classpath: org.apache.flink.cdc.udf.examples.%s.AddOneFunctionClass\n"
-                                + "    - name: format\n"
-                                + "      classpath: org.apache.flink.cdc.udf.examples.%s.FormatFunctionClass\n"
-                                + "    - name: lifecycle\n"
-                                + "      classpath: org.apache.flink.cdc.udf.examples.%s.LifecycleFunctionClass\n"
-                                + "    - name: typeof\n"
-                                + "      classpath: org.apache.flink.cdc.udf.examples.%s.TypeOfFunctionClass\n"
-                                + "    - name: answer\n"
-                                + "      classpath: org.apache.flink.cdc.udf.examples.%s.TypeHintFunctionClass\n",
-                        INTER_CONTAINER_MYSQL_ALIAS,
-                        MYSQL_TEST_USER,
-                        MYSQL_TEST_PASSWORD,
-                        transformRenameDatabase.getDatabaseName(),
-                        transformRenameDatabase.getDatabaseName(),
-                        transformRenameDatabase.getDatabaseName(),
-                        parallelism,
-                        language,
-                        language,
-                        language,
-                        language,
-                        language);
-        Path mysqlCdcJar = TestUtils.getResource("mysql-cdc-pipeline-connector.jar");
-        Path valuesCdcJar = TestUtils.getResource("values-cdc-pipeline-connector.jar");
-        Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
-        Path udfJar = TestUtils.getResource("udf-examples.jar");
-        Path scalaLibJar = TestUtils.getResource("scala-library.jar");
-        submitPipelineJob(
-                pipelineJob, mysqlCdcJar, valuesCdcJar, mysqlDriverJar, udfJar, scalaLibJar);
-        waitUntilJobRunning(Duration.ofSeconds(30));
-        LOG.info("Pipeline job is running");
-
-        waitUntilSpecificEvent("[ LifecycleFunction ] opened.", 60000L);
-
-        waitUntilSpecificEvent(
-                String.format(
-                        "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1011, 11, 1013, <11>], op=INSERT, meta=()}",
-                        transformRenameDatabase.getDatabaseName()),
-                60000L);
-
-        waitUntilSpecificEvent(
-                String.format(
-                        "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2014, 14, Forty-two, Integer: 2014], op=INSERT, meta=()}",
-                        transformRenameDatabase.getDatabaseName()),
-                60000L);
-
-        List<String> expectedEvents =
-                Arrays.asList(
-                        String.format(
-                                "CreateTableEvent{tableId=%s.TABLEALPHA, schema=columns={`ID` INT NOT NULL,`VERSION` VARCHAR(17),`INC_ID` STRING,`FMT_VER` STRING}, primaryKeys=ID, options=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "CreateTableEvent{tableId=%s.TABLEBETA, schema=columns={`ID` INT NOT NULL,`VERSION` VARCHAR(17),`ANS` STRING,`TYP` STRING}, primaryKeys=ID, options=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1009, 8.1, 1011, <8.1>], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1010, 10, 1012, <10>], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1011, 11, 1013, <11>], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2011, 11, Forty-two, Integer: 2011], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2012, 12, Forty-two, Integer: 2012], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2013, 13, Forty-two, Integer: 2013], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2014, 14, Forty-two, Integer: 2014], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()));
-        validateResult(expectedEvents);
-    }
-
-    private void testFlinkCompatibleScalarFunctions(String language) throws Exception {
+    @ParameterizedTest(name = "language: {0}, batchMode: {1}")
+    @MethodSource(value = "variants")
+    void testFlinkCompatibleScalarFunctions(String language, boolean batchMode) throws Exception {
         String pipelineJob =
                 String.format(
                         "source:\n"
@@ -391,6 +263,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                                 + "\n"
                                 + "pipeline:\n"
                                 + "  parallelism: %d\n"
+                                + "  batch-mode.enabled: %s\n"
                                 + "  user-defined-function:\n"
                                 + "    - name: addone\n"
                                 + "      classpath: org.apache.flink.udf.examples.%s.AddOneFunctionClass\n"
@@ -405,6 +278,7 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                         transformRenameDatabase.getDatabaseName(),
                         transformRenameDatabase.getDatabaseName(),
                         parallelism,
+                        batchMode,
                         language,
                         language,
                         language);
@@ -497,103 +371,6 @@ class UdfE2eITCase extends PipelineTestEnvironment {
                         "DataChangeEvent{tableId=%s.TABLEBETA, before=[2011, 11, Integer: 2011], after=[], op=DELETE, meta=()}",
                         transformRenameDatabase.getDatabaseName()),
                 20000L);
-    }
-
-    private void testFlinkCompatibleScalarFunctionsInBatchMode(String language) throws Exception {
-        String pipelineJob =
-                String.format(
-                        "source:\n"
-                                + "  type: mysql\n"
-                                + "  hostname: %s\n"
-                                + "  port: 3306\n"
-                                + "  username: %s\n"
-                                + "  password: %s\n"
-                                + "  tables: %s.\\.*\n"
-                                + "  server-id: 5400-5404\n"
-                                + "  server-time-zone: UTC\n"
-                                + "  scan.startup.mode: snapshot\n"
-                                + "\n"
-                                + "sink:\n"
-                                + "  type: values\n"
-                                + "transform:\n"
-                                + "  - source-table: %s.TABLEALPHA\n"
-                                + "    projection: ID, VERSION, addone(addone(ID)) AS INC_ID, format('<%%s>', VERSION) AS FMT_VER\n"
-                                + "    filter: addone(ID) <> '1009'\n"
-                                + "  - source-table: %s.TABLEBETA\n"
-                                + "    projection: ID, VERSION, typeof(ID) AS TYP\n"
-                                + "\n"
-                                + "pipeline:\n"
-                                + "  parallelism: %d\n"
-                                + "  batch-mode.enabled: true\n"
-                                + "  user-defined-function:\n"
-                                + "    - name: addone\n"
-                                + "      classpath: org.apache.flink.udf.examples.%s.AddOneFunctionClass\n"
-                                + "    - name: format\n"
-                                + "      classpath: org.apache.flink.udf.examples.%s.FormatFunctionClass\n"
-                                + "    - name: typeof\n"
-                                + "      classpath: org.apache.flink.udf.examples.%s.TypeOfFunctionClass\n",
-                        INTER_CONTAINER_MYSQL_ALIAS,
-                        MYSQL_TEST_USER,
-                        MYSQL_TEST_PASSWORD,
-                        transformRenameDatabase.getDatabaseName(),
-                        transformRenameDatabase.getDatabaseName(),
-                        transformRenameDatabase.getDatabaseName(),
-                        parallelism,
-                        language,
-                        language,
-                        language);
-        Path mysqlCdcJar = TestUtils.getResource("mysql-cdc-pipeline-connector.jar");
-        Path valuesCdcJar = TestUtils.getResource("values-cdc-pipeline-connector.jar");
-        Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
-        Path udfJar = TestUtils.getResource("udf-examples.jar");
-        Path scalaLibJar = TestUtils.getResource("scala-library.jar");
-        submitPipelineJob(
-                pipelineJob, mysqlCdcJar, valuesCdcJar, mysqlDriverJar, udfJar, scalaLibJar);
-        waitUntilJobRunning(Duration.ofSeconds(30));
-        LOG.info("Pipeline job is running");
-
-        waitUntilSpecificEvent(
-                String.format(
-                        "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1011, 11, 1013, <11>], op=INSERT, meta=()}",
-                        transformRenameDatabase.getDatabaseName()),
-                60000L);
-
-        waitUntilSpecificEvent(
-                String.format(
-                        "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2014, 14, Integer: 2014], op=INSERT, meta=()}",
-                        transformRenameDatabase.getDatabaseName()),
-                60000L);
-
-        List<String> expectedEvents =
-                Arrays.asList(
-                        String.format(
-                                "CreateTableEvent{tableId=%s.TABLEALPHA, schema=columns={`ID` INT NOT NULL,`VERSION` VARCHAR(17),`INC_ID` STRING,`FMT_VER` STRING}, primaryKeys=ID, options=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "CreateTableEvent{tableId=%s.TABLEBETA, schema=columns={`ID` INT NOT NULL,`VERSION` VARCHAR(17),`TYP` STRING}, primaryKeys=ID, options=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1009, 8.1, 1011, <8.1>], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1010, 10, 1012, <10>], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEALPHA, before=[], after=[1011, 11, 1013, <11>], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2011, 11, Integer: 2011], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2012, 12, Integer: 2012], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2013, 13, Integer: 2013], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()),
-                        String.format(
-                                "DataChangeEvent{tableId=%s.TABLEBETA, before=[], after=[2014, 14, Integer: 2014], op=INSERT, meta=()}",
-                                transformRenameDatabase.getDatabaseName()));
-        validateResult(expectedEvents);
     }
 
     private void validateResult(List<String> expectedEvents) throws Exception {


### PR DESCRIPTION
There's no difference between UDF e2e cases in streaming and batch mode, since it doesn't involve any schema evolution, incremental changes, etc. Merging them together to reduce sloc.